### PR TITLE
Adds card liking button to cards

### DIFF
--- a/src/app/card-component/card.component.html
+++ b/src/app/card-component/card.component.html
@@ -10,7 +10,7 @@
         <div class="card-example-usage card-line" [ngClass]="{'hint-selected': this.selected.indexOf(4) != -1}"><div class="card-desc">Example usage:</div> <div class="card-cont">{{ card.example_usage }}</div></div>
     </mat-card-content>
     <mat-card-actions align="end">
-        <button mat-icon-button color="primary" [disabled]="DisableButton" class="card-vote"(click)= "hitUpvote()">
+        <button mat-icon-button color="primary" [disabled]="DisableButton" class="card-vote"(click)= "hitLike()">
             <mat-icon>thumb_up</mat-icon>
         </button>
     </mat-card-actions>

--- a/src/app/card-component/card.component.html
+++ b/src/app/card-component/card.component.html
@@ -1,10 +1,18 @@
 <mat-card>
-    <mat-card-title class="card-word">{{ card.word }}</mat-card-title>
+    <mat-card-header>
+        <mat-card-title class="card-word">{{ card.word }}</mat-card-title>
+    </mat-card-header>
     <mat-divider></mat-divider>
     <mat-card-content>
-        <div class="card-synonym card-line" [ngClass]="{'hint-selected': this.selected.indexOf(1) != -1}"><div class="card-desc">Synonym:</div> <div class="card-cont">{{ card.synonym }}</div></div>
-        <div class="card-antonym card-line" [ngClass]="{'hint-selected': this.selected.indexOf(2) != -1}"><div class="card-desc">Antonym:</div> <div class="card-cont">{{ card.antonym }}</div></div>
-        <div class="card-general-usage card-line" [ngClass]="{'hint-selected': this.selected.indexOf(3) != -1}"><div class="card-desc">General usage:</div> <div class="card-cont">{{ card.general_sense }}</div></div>
+        <div class="card-synonym card-line" [ngClass]="{'hint-selected': this.selected.indexOf(1) != -1}"><div class="card-desc">Synonym:</div> <div class="card-cont">{{ card.synonym }}</div></div><br>
+        <div class="card-antonym card-line" [ngClass]="{'hint-selected': this.selected.indexOf(2) != -1}"><div class="card-desc">Antonym:</div> <div class="card-cont">{{ card.antonym }}</div></div><br>
+        <div class="card-general-usage card-line" [ngClass]="{'hint-selected': this.selected.indexOf(3) != -1}"><div class="card-desc">General usage:</div> <div class="card-cont">{{ card.general_sense }}</div></div><br>
         <div class="card-example-usage card-line" [ngClass]="{'hint-selected': this.selected.indexOf(4) != -1}"><div class="card-desc">Example usage:</div> <div class="card-cont">{{ card.example_usage }}</div></div>
     </mat-card-content>
+    <mat-card-actions align="end">
+        <button mat-icon-button color="primary" [disabled]="DisableButton" class="card-vote"(click)= "hitUpvote()">
+            <mat-icon>thumb_up</mat-icon>
+        </button>
+    </mat-card-actions>
+
 </mat-card>

--- a/src/app/card-component/card.component.scss
+++ b/src/app/card-component/card.component.scss
@@ -1,13 +1,8 @@
 .hint-selected {
     background-color: yellow;
 }
-.card-line {
-    margin-top: 5px;
-
-}
+.card-line {  margin-top: 5px; }
 .card-desc { float: left; width: 120px; }
 .card-cont { margin-left: 120px; }
-
-.card-word, .card-cont {
-    word-wrap: break-word;
-}
+.card-vote { bottom: 0; position: absolute;}
+.card-word, .card-cont {  word-wrap: break-word; }

--- a/src/app/card-component/card.component.spec.ts
+++ b/src/app/card-component/card.component.spec.ts
@@ -9,6 +9,7 @@ import {Component} from "@angular/core";
 import {Card} from "../card/card";
 import {browser} from "protractor";
 
+
 describe('CardComponent', () => {
   let component: CardComponent;
   let fixture: ComponentFixture<TestComponentWrapper>;
@@ -41,7 +42,6 @@ describe('CardComponent', () => {
         expect(component.card.general_sense).toContain("test general_sense");
         expect(component.card.example_usage).toContain("test example_usage");
 
-
     });
 
      it('synonym should be highlighted', () => {
@@ -63,6 +63,28 @@ describe('CardComponent', () => {
         let synonym: HTMLElement = debugElement.query(By.css('.card-example-usage')).nativeElement;
         expect(synonym.classList).not.toContain("hint-selected");
     });
+
+    it('should check whether the button has been called', async(() => {
+        spyOn(component, 'hitLike');
+
+        let button = fixture.debugElement.nativeElement.querySelector('button');
+        button.click();
+
+        fixture.whenStable().then(() => {
+            expect(component.hitLike).toHaveBeenCalled();
+        })
+    }));
+    it('should increment the like by 1', async(() => {
+        spyOn(component, 'hitLike');
+
+        let button = fixture.debugElement.nativeElement.querySelector('button');
+        button.click();
+
+        fixture.whenStable().then(() => {
+            expect(this.likes = 1);
+        })
+    }));
+
 });
 
 @Component({
@@ -76,6 +98,7 @@ class TestComponentWrapper {
         antonym: "test antonym",
         general_sense: "test general_sense",
         example_usage: "test example_usage",
+        likes: 0
     };
 
 

--- a/src/app/card-component/card.component.ts
+++ b/src/app/card-component/card.component.ts
@@ -8,6 +8,8 @@ import {Card} from "../card/card";
 })
 export class CardComponent implements OnInit {
 
+    DisableButton: boolean = false;
+
   constructor() {
   }
 
@@ -16,6 +18,13 @@ export class CardComponent implements OnInit {
   @Input() selected?: number[] = [];
 
   ngOnInit() {
+  }
+
+  hitUpvote(): number {
+      this.card.likes += 1;
+      this.DisableButton = true;
+      console.log(this.card.likes);
+      return this.card.likes;
   }
 
 }

--- a/src/app/card-component/card.component.ts
+++ b/src/app/card-component/card.component.ts
@@ -20,7 +20,7 @@ export class CardComponent implements OnInit {
   ngOnInit() {
   }
 
-  hitUpvote(): number {
+  hitLike(): number {
       this.card.likes += 1;
       this.DisableButton = true;
       console.log(this.card.likes);

--- a/src/app/card/card.ts
+++ b/src/app/card/card.ts
@@ -4,5 +4,6 @@ export interface Card {
     synonym: string,
     antonym: string,
     general_sense: string,
-    example_usage: string
+    example_usage: string,
+    likes: number;
 }

--- a/src/app/deck/deck.service.ts
+++ b/src/app/deck/deck.service.ts
@@ -34,13 +34,14 @@ export class DeckService {
     }
 
     public addNewCard(deckID: string, word: string, synonym: string, antonym: string, general: string, example: string) {
-        const body : Card = {
+        const body: Card = {
             word: word,
             synonym: synonym,
             antonym: antonym,
             general_sense: general,
-            example_usage: example
-        }
+            example_usage: example,
+            likes: 0
+        };
         console.log(body);
 
         return this.db.doc('decks/' + deckID).collection('cards').add(body);

--- a/src/app/new-card-dialog/new-card-dialog.component.ts
+++ b/src/app/new-card-dialog/new-card-dialog.component.ts
@@ -51,7 +51,8 @@ export class NewCardDialogComponent implements OnInit {
             this.newCardSynonym,
             this.newCardAntonym,
             this.newCardGeneral,
-            this.newCardExample).then(
+            this.newCardExample,
+            ).then(
             succeeded => {
                 //this.cardAddSuccess = true;
                 this.matDialogRef.close(succeeded);


### PR DESCRIPTION
Adds like button and fixes word wrapping in the card container.
Screenshot:
![changesvotebranch](https://user-images.githubusercontent.com/6532730/32124920-543abdc6-bb2f-11e7-888e-1169527b5559.png)

- Fixes the issue when the string in the card was larger than the width of the card.
- Added a button to render the like.
- Like button is disabled after it is clicked and the global state of total number of like of the particular card increments by 1.
- Changed the position of the button to be aligned at the end of the card.

This closes #8.