### PR TITLE
Delete Class button now only shows for teacher

### DIFF
--- a/src/app/class-component/class.component.html
+++ b/src/app/class-component/class.component.html
@@ -2,12 +2,12 @@
     <div flex-gt-xs="80" flex-offset-gt-xs="10" flex-xs="96" flex-offset-xs="2">
         <mat-card>
             <div layout="row" layout-align="space-between center">
-            <mat-card-title flex id="decks-title" *ngIf="this.currentClass ">{{ this.currentClass.name }}</mat-card-title>
+            <mat-card-title flex id="decks-title" *ngIf="this.currentClass">{{ this.currentClass.name }}</mat-card-title>
             <button mat-icon-button [matMenuTriggerFor]="menu">
                 <mat-icon>more_vert</mat-icon>
             </button>
             <mat-menu #menu="matMenu">
-                <button mat-menu-item (click)="this.deleteClass()">
+                <button *ngIf="this.canEdit" mat-menu-item (click)="this.deleteClass()">
                     <mat-icon>delete</mat-icon>
                     <span>Delete Class</span>
                 </button>


### PR DESCRIPTION
Though right now students just see a clickable menu that doesn't give any options. This is fine because later that menu will include student-inclusive options such as leaving the class. This closes #85 

|![localhost_9000_class_lia5fauwti4zgmjlfcwy iphone 6 plus 1](https://user-images.githubusercontent.com/25711751/33506126-0564fef0-d6b4-11e7-95ba-c7621d2a6005.png)|
![localhost_9000_class_lia5fauwti4zgmjlfcwy iphone 6 plus](https://user-images.githubusercontent.com/25711751/33506129-072f1644-d6b4-11e7-9d8c-ef3ae290d219.png)|
|---|---|