### PR TITLE
Fix testing errors from Angular Material

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,9 @@ module.exports = function (config) {
             require('karma-coverage-istanbul-reporter'),
             require('@angular/cli/plugins/karma')
         ],
+        files: [
+            { pattern: './node_modules/@angular/material/prebuilt-themes/indigo-pink.css' }
+        ],
         client: {
             clearContext: false // leave Jasmine Spec Runner output visible in browser
         },


### PR DESCRIPTION
Fixes the `'Could not find Angular Material core theme. Most Material components may not work as expected. For more info refer to the theming guide: https://material.angular.io/guide/theming'` errors by including a basic theme when testing.